### PR TITLE
Add alsa-utils and firmware-amd-graphics as dependencies

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -47,7 +47,9 @@ common_dependencies:
 - libogg0
 - libvorbis0a
 - libasound2
+- alsa-utils
 - xorg
 - lightdm
 - libpulse0
 - mesa-vulkan-drivers
+- firmware-amd-graphics


### PR DESCRIPTION
This PR adds a couple dependencies I believe are needed for this project:

`firmware-amd-graphics` is required for any PC using an AMD/Radeon graphics card, since the game refuses to launch unless booting with the `nomodeset` parameter.

`alsa-utils` adds a number of utilities that help with configuring and troubleshooting sound, such as `amixer` for increasing the volume, `aplay` for identifying playback devices and `speaker-test` for... testing speakers.